### PR TITLE
refactor: use interfaces where possible

### DIFF
--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -17,13 +17,18 @@ import (
 	"go.bonk.build/pkg/backend"
 )
 
+type BackendRegistrar interface {
+	RegisterBackend(name string, impl backend.Backend) error
+	UnregisterBackend(name string)
+}
+
 type PluginManager struct {
 	plugins map[string]*Plugin
 
-	backend *backend.BackendManager
+	backend BackendRegistrar
 }
 
-func NewPluginManager(backend *backend.BackendManager) *PluginManager {
+func NewPluginManager(backend BackendRegistrar) *PluginManager {
 	pm := &PluginManager{}
 	pm.plugins = make(map[string]*Plugin)
 	pm.backend = backend

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -9,18 +9,21 @@ import (
 
 	gotaskflow "github.com/noneback/go-taskflow"
 
-	"go.bonk.build/pkg/backend"
 	"go.bonk.build/pkg/task"
 )
 
+type TaskSender interface {
+	SendTask(tsk task.Task) error
+}
+
 type Scheduler struct {
-	backendManager *backend.BackendManager
+	backendManager TaskSender
 	executor       gotaskflow.Executor
 	tasks          map[string]*gotaskflow.Task
 	rootFlow       *gotaskflow.TaskFlow
 }
 
-func NewScheduler(backendManager *backend.BackendManager, concurrency uint) *Scheduler {
+func NewScheduler(backendManager TaskSender, concurrency uint) *Scheduler {
 	return &Scheduler{
 		backendManager: backendManager,
 		executor:       gotaskflow.NewExecutor(concurrency),


### PR DESCRIPTION
This helps cut down on internal dependencies and allows more flexibility.
