### PR TITLE
refactor: track outputs per execution

### DIFF
--- a/api/go/proto/bonk/v0/plugin.pb.go
+++ b/api/go/proto/bonk/v0/plugin.pb.go
@@ -581,9 +581,10 @@ func (b0 PerformTaskRequest_builder) Build() *PerformTaskRequest {
 }
 
 type PerformTaskResponse struct {
-	state         protoimpl.MessageState `protogen:"opaque.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Output []string               `protobuf:"bytes,1,rep,name=output"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *PerformTaskResponse) Reset() {
@@ -611,23 +612,35 @@ func (x *PerformTaskResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+func (x *PerformTaskResponse) GetOutput() []string {
+	if x != nil {
+		return x.xxx_hidden_Output
+	}
+	return nil
+}
+
+func (x *PerformTaskResponse) SetOutput(v []string) {
+	x.xxx_hidden_Output = v
+}
+
 type PerformTaskResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	Output []string
 }
 
 func (b0 PerformTaskResponse_builder) Build() *PerformTaskResponse {
 	m0 := &PerformTaskResponse{}
 	b, x := &b0, m0
 	_, _ = b, x
+	x.xxx_hidden_Output = b.Output
 	return m0
 }
 
 type ConfigurePluginResponse_ExecutorDescription struct {
-	state              protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Outputs []string               `protobuf:"bytes,1,rep,name=outputs"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ConfigurePluginResponse_ExecutorDescription) Reset() {
@@ -655,28 +668,15 @@ func (x *ConfigurePluginResponse_ExecutorDescription) ProtoReflect() protoreflec
 	return mi.MessageOf(x)
 }
 
-func (x *ConfigurePluginResponse_ExecutorDescription) GetOutputs() []string {
-	if x != nil {
-		return x.xxx_hidden_Outputs
-	}
-	return nil
-}
-
-func (x *ConfigurePluginResponse_ExecutorDescription) SetOutputs(v []string) {
-	x.xxx_hidden_Outputs = v
-}
-
 type ConfigurePluginResponse_ExecutorDescription_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Outputs []string
 }
 
 func (b0 ConfigurePluginResponse_ExecutorDescription_builder) Build() *ConfigurePluginResponse_ExecutorDescription {
 	m0 := &ConfigurePluginResponse_ExecutorDescription{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_Outputs = b.Outputs
 	return m0
 }
 
@@ -685,12 +685,11 @@ var File_bonk_v0_plugin_proto protoreflect.FileDescriptor
 const file_bonk_v0_plugin_proto_rawDesc = "" +
 	"\n" +
 	"\x14bonk/v0/plugin.proto\x12\abonk.v0\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x18\n" +
-	"\x16ConfigurePluginRequest\"\xbd\x03\n" +
+	"\x16ConfigurePluginRequest\"\xa3\x03\n" +
 	"\x17ConfigurePluginResponse\x12I\n" +
 	"\bfeatures\x18\x01 \x03(\x0e2-.bonk.v0.ConfigurePluginResponse.FeatureFlagsR\bfeatures\x12M\n" +
-	"\texecutors\x18\x03 \x03(\v2/.bonk.v0.ConfigurePluginResponse.ExecutorsEntryR\texecutors\x1a/\n" +
-	"\x13ExecutorDescription\x12\x18\n" +
-	"\aoutputs\x18\x01 \x03(\tR\aoutputs\x1ar\n" +
+	"\texecutors\x18\x03 \x03(\v2/.bonk.v0.ConfigurePluginResponse.ExecutorsEntryR\texecutors\x1a\x15\n" +
+	"\x13ExecutorDescription\x1ar\n" +
 	"\x0eExecutorsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12J\n" +
 	"\x05value\x18\x02 \x01(\v24.bonk.v0.ConfigurePluginResponse.ExecutorDescriptionR\x05value:\x028\x01\"R\n" +
@@ -716,8 +715,9 @@ const file_bonk_v0_plugin_proto_rawDesc = "" +
 	"\n" +
 	"parameters\x18\x03 \x01(\v2\x17.google.protobuf.StructR\n" +
 	"parameters\x12#\n" +
-	"\rout_directory\x18\x04 \x01(\tR\foutDirectory\"\x15\n" +
-	"\x13PerformTaskResponse2\xfc\x01\n" +
+	"\rout_directory\x18\x04 \x01(\tR\foutDirectory\"-\n" +
+	"\x13PerformTaskResponse\x12\x16\n" +
+	"\x06output\x18\x01 \x03(\tR\x06output2\xfc\x01\n" +
 	"\x11BonkPluginService\x12T\n" +
 	"\x0fConfigurePlugin\x12\x1f.bonk.v0.ConfigurePluginRequest\x1a .bonk.v0.ConfigurePluginResponse\x12G\n" +
 	"\n" +

--- a/api/proto/bonk/v0/plugin.proto
+++ b/api/proto/bonk/v0/plugin.proto
@@ -18,7 +18,6 @@ message ConfigurePluginResponse {
   }
 
   message ExecutorDescription {
-    repeated string outputs = 1;
   }
 
   // Prep for front end support
@@ -50,7 +49,9 @@ message PerformTaskRequest {
   string out_directory = 4;
 }
 
-message PerformTaskResponse {}
+message PerformTaskResponse {
+  repeated string output = 1;
+}
 
 service BonkPluginService {
   // General plugin support

--- a/docs/api/go.md
+++ b/docs/api/go.md
@@ -12,7 +12,7 @@ import "go.bonk.build/api/go"
 - [Variables](<#variables>)
 - [func Serve\(executors ...BonkExecutor\)](<#Serve>)
 - [type BonkExecutor](<#BonkExecutor>)
-  - [func NewExecutor\[Params any\]\(name string, outputs \[\]string, exec func\(context.Context, \*TaskParams\[Params\]\) error\) BonkExecutor](<#NewExecutor>)
+  - [func NewExecutor\[Params any\]\(name string, exec func\(context.Context, \*TaskParams\[Params\]\) \(\[\]string, error\)\) BonkExecutor](<#NewExecutor>)
 - [type BonkPluginServer](<#BonkPluginServer>)
   - [func \(p \*BonkPluginServer\) GRPCClient\(\_ context.Context, \_ \*goplugin.GRPCBroker, c \*grpc.ClientConn\) \(any, error\)](<#BonkPluginServer.GRPCClient>)
   - [func \(p \*BonkPluginServer\) GRPCServer\(\_ \*goplugin.GRPCBroker, s \*grpc.Server\) error](<#BonkPluginServer.GRPCServer>)
@@ -40,7 +40,7 @@ var Handshake = goplugin.HandshakeConfig{
 ```
 
 <a name="Serve"></a>
-## func [Serve](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L77>)
+## func [Serve](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L75>)
 
 ```go
 func Serve(executors ...BonkExecutor)
@@ -58,21 +58,21 @@ type BonkExecutor struct {
     Name         string
     Outputs      []string
     ParamsSchema cue.Value
-    Exec         func(context.Context, TaskParams[cue.Value]) error
+    Exec         func(context.Context, TaskParams[cue.Value]) ([]string, error)
 }
 ```
 
 <a name="NewExecutor"></a>
-### func [NewExecutor](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L46-L50>)
+### func [NewExecutor](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L46-L49>)
 
 ```go
-func NewExecutor[Params any](name string, outputs []string, exec func(context.Context, *TaskParams[Params]) error) BonkExecutor
+func NewExecutor[Params any](name string, exec func(context.Context, *TaskParams[Params]) ([]string, error)) BonkExecutor
 ```
 
 Factory to create a new task executor.
 
 <a name="BonkPluginServer"></a>
-## type [BonkPluginServer](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L103-L108>)
+## type [BonkPluginServer](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L101-L106>)
 
 
 
@@ -86,7 +86,7 @@ type BonkPluginServer struct {
 ```
 
 <a name="BonkPluginServer.GRPCClient"></a>
-### func \(\*BonkPluginServer\) [GRPCClient](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L119-L123>)
+### func \(\*BonkPluginServer\) [GRPCClient](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L117-L121>)
 
 ```go
 func (p *BonkPluginServer) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error)
@@ -95,7 +95,7 @@ func (p *BonkPluginServer) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker,
 
 
 <a name="BonkPluginServer.GRPCServer"></a>
-### func \(\*BonkPluginServer\) [GRPCServer](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L110>)
+### func \(\*BonkPluginServer\) [GRPCServer](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L108>)
 
 ```go
 func (p *BonkPluginServer) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error
@@ -110,8 +110,8 @@ The inputs passed to a task executor.
 
 ```go
 type TaskParams[Params any] struct {
-    Params Params
     Inputs []string
+    Params Params
     OutDir string
 }
 ```

--- a/docs/api/go.md
+++ b/docs/api/go.md
@@ -40,7 +40,7 @@ var Handshake = goplugin.HandshakeConfig{
 ```
 
 <a name="Serve"></a>
-## func [Serve](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L75>)
+## func [Serve](<https://github.com/bonk-build/bonk/blob/f93245d/api/go/plugin.go#L75>)
 
 ```go
 func Serve(executors ...BonkExecutor)
@@ -49,7 +49,7 @@ func Serve(executors ...BonkExecutor)
 Call from main\(\) to start the plugin gRPC server.
 
 <a name="BonkExecutor"></a>
-## type [BonkExecutor](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L38-L43>)
+## type [BonkExecutor](<https://github.com/bonk-build/bonk/blob/f93245d/api/go/plugin.go#L38-L43>)
 
 Represents a executor capable of performing tasks.
 
@@ -63,7 +63,7 @@ type BonkExecutor struct {
 ```
 
 <a name="NewExecutor"></a>
-### func [NewExecutor](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L46-L49>)
+### func [NewExecutor](<https://github.com/bonk-build/bonk/blob/f93245d/api/go/plugin.go#L46-L49>)
 
 ```go
 func NewExecutor[Params any](name string, exec func(context.Context, *TaskParams[Params]) ([]string, error)) BonkExecutor
@@ -72,7 +72,7 @@ func NewExecutor[Params any](name string, exec func(context.Context, *TaskParams
 Factory to create a new task executor.
 
 <a name="BonkPluginServer"></a>
-## type [BonkPluginServer](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L101-L106>)
+## type [BonkPluginServer](<https://github.com/bonk-build/bonk/blob/f93245d/api/go/plugin.go#L101-L106>)
 
 
 
@@ -86,7 +86,7 @@ type BonkPluginServer struct {
 ```
 
 <a name="BonkPluginServer.GRPCClient"></a>
-### func \(\*BonkPluginServer\) [GRPCClient](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L117-L121>)
+### func \(\*BonkPluginServer\) [GRPCClient](<https://github.com/bonk-build/bonk/blob/f93245d/api/go/plugin.go#L117-L121>)
 
 ```go
 func (p *BonkPluginServer) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error)
@@ -95,7 +95,7 @@ func (p *BonkPluginServer) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker,
 
 
 <a name="BonkPluginServer.GRPCServer"></a>
-### func \(\*BonkPluginServer\) [GRPCServer](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L108>)
+### func \(\*BonkPluginServer\) [GRPCServer](<https://github.com/bonk-build/bonk/blob/f93245d/api/go/plugin.go#L108>)
 
 ```go
 func (p *BonkPluginServer) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error
@@ -104,7 +104,7 @@ func (p *BonkPluginServer) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) er
 
 
 <a name="TaskParams"></a>
-## type [TaskParams](<https://github.com/bonk-build/bonk/blob/dd19c33/api/go/plugin.go#L31-L35>)
+## type [TaskParams](<https://github.com/bonk-build/bonk/blob/f93245d/api/go/plugin.go#L31-L35>)
 
 The inputs passed to a task executor.
 

--- a/pkg/executor/backend.go
+++ b/pkg/executor/backend.go
@@ -10,5 +10,5 @@ import (
 )
 
 type Executor interface {
-	Execute(ctx context.Context, tsk task.Task) error
+	Execute(ctx context.Context, tsk task.Task) ([]string, error)
 }

--- a/pkg/executor/manager.go
+++ b/pkg/executor/manager.go
@@ -36,20 +36,20 @@ func (bm *ExecutorManager) UnregisterExecutor(name string) {
 	delete(bm.executors, name)
 }
 
-func (bm *ExecutorManager) SendTask(ctx context.Context, tsk task.Task) error {
+func (bm *ExecutorManager) SendTask(ctx context.Context, tsk task.Task) ([]string, error) {
 	executorName := tsk.Executor()
 
 	executor, ok := bm.executors[executorName]
 	if !ok {
-		return fmt.Errorf("Executor %s not found", executorName)
+		return nil, fmt.Errorf("Executor %s not found", executorName)
 	}
 
-	err := executor.Execute(ctx, tsk)
+	outputs, err := executor.Execute(ctx, tsk)
 	if err != nil {
-		return fmt.Errorf("failed to execute task: %w", err)
+		return nil, fmt.Errorf("failed to execute task: %w", err)
 	}
 
-	return nil
+	return outputs, nil
 }
 
 func (bm *ExecutorManager) Shutdown() {

--- a/pkg/executor/rpc.go
+++ b/pkg/executor/rpc.go
@@ -25,7 +25,7 @@ type rpcExecutor struct {
 	client bonkv0.BonkPluginServiceClient
 }
 
-func (pb *rpcExecutor) Execute(ctx context.Context, tsk task.Task) error {
+func (pb *rpcExecutor) Execute(ctx context.Context, tsk task.Task) ([]string, error) {
 	outDir := tsk.GetOutputDirectory()
 	taskReqBuilder := bonkv0.PerformTaskRequest_builder{
 		Executor:     &pb.name,
@@ -36,13 +36,13 @@ func (pb *rpcExecutor) Execute(ctx context.Context, tsk task.Task) error {
 
 	err := tsk.Params.Decode(taskReqBuilder.Parameters)
 	if err != nil {
-		return fmt.Errorf("failed to encode parameters as protobuf: %w", err)
+		return nil, fmt.Errorf("failed to encode parameters as protobuf: %w", err)
 	}
 
-	_, err = pb.client.PerformTask(ctx, taskReqBuilder.Build())
+	res, err := pb.client.PerformTask(ctx, taskReqBuilder.Build())
 	if err != nil {
-		return fmt.Errorf("failed to call perform task: %w", err)
+		return nil, fmt.Errorf("failed to call perform task: %w", err)
 	}
 
-	return nil
+	return res.GetOutput(), nil
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -36,24 +36,27 @@ func NewScheduler(executorManager TaskSender, concurrency uint) *Scheduler {
 func (s *Scheduler) AddTask(tsk task.Task, deps ...string) error {
 	taskName := tsk.ID.String()
 	newTask := s.rootFlow.NewTask(taskName, func() {
-		if tsk.CheckChecksum() {
-			slog.Debug("checksums match, skipping task")
+		mismatches := tsk.DetectStateMismatches()
+		if mismatches == nil {
+			slog.Debug("states match, skipping task")
 
 			return
 		}
 
-		_, err := s.executorManager.SendTask(context.Background(), tsk)
+		slog.Debug("state mismatch, running task", "mismatches", mismatches)
+
+		outputs, err := s.executorManager.SendTask(context.Background(), tsk)
 		if err != nil {
 			slog.Error("error executing task", "task", taskName, "error", err)
 
 			return
 		}
 
-		slog.Info("task succeeded, saving checksum")
+		slog.Info("task succeeded, saving state")
 
-		err = tsk.SaveChecksum()
+		err = tsk.SaveState(outputs)
 		if err != nil {
-			slog.Error("failed to checksum task", "error", err)
+			slog.Error("failed to save task state", "error", err)
 
 			return
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -14,7 +14,7 @@ import (
 )
 
 type TaskSender interface {
-	SendTask(ctx context.Context, tsk task.Task) error
+	SendTask(ctx context.Context, tsk task.Task) ([]string, error)
 }
 
 type Scheduler struct {
@@ -42,7 +42,7 @@ func (s *Scheduler) AddTask(tsk task.Task, deps ...string) error {
 			return
 		}
 
-		err := s.executorManager.SendTask(context.Background(), tsk)
+		_, err := s.executorManager.SendTask(context.Background(), tsk)
 		if err != nil {
 			slog.Error("error executing task", "task", taskName, "error", err)
 

--- a/pkg/task/state.go
+++ b/pkg/task/state.go
@@ -1,0 +1,167 @@
+// Copyright © 2025 Colden Cullen
+// SPDX-License-Identifier: MIT
+
+package task
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"reflect"
+
+	"go.uber.org/multierr"
+
+	"cuelang.org/go/cue"
+)
+
+const StateFile = "state.json"
+
+type State struct {
+	// Cache provided executor & outputs
+	Executor string   `json:"executor,omitempty"`
+	Inputs   []string `json:"inputs,omitempty"`
+	Outputs  []string `json:"outputs,omitempty"`
+
+	ParamsChecksum  []byte `json:"paramsChecksum,omitempty"`
+	InputsChecksum  []byte `json:"inputChecksum,omitempty"`
+	OutputsChecksum []byte `json:"outputsChecksum,omitempty"`
+}
+
+func NewState(
+	executor string,
+	params cue.Value,
+	root *os.Root,
+	inputs, outputs []string,
+) (*State, error) {
+	var err error
+	state := &State{}
+	state.Executor = executor
+	state.Inputs = inputs
+	state.Outputs = outputs
+
+	hasher := sha256.New()
+
+	// Hash the parameters
+	state.ParamsChecksum, err = hashParams(hasher, params)
+	if err != nil {
+		return state, err
+	}
+
+	// Hash the input files
+	state.InputsChecksum, err = hashFiles(hasher, nil, inputs)
+	if err != nil {
+		return state, err
+	}
+
+	// Hash the input files
+	state.OutputsChecksum, err = hashFiles(hasher, root, outputs)
+	if err != nil {
+		return state, err
+	}
+
+	return state, err
+}
+
+func LoadState(root *os.Root) (*State, error) {
+	file, err := root.Open(StateFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open state file %s: %w", StateFile, err)
+	}
+	encoder := json.NewDecoder(file)
+
+	state := &State{}
+	err = encoder.Decode(state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode state file %s: %w", StateFile, err)
+	}
+
+	return state, nil
+}
+
+func (s *State) Save(root *os.Root) error {
+	file, err := root.Create(StateFile)
+	if err != nil {
+		return fmt.Errorf("failed to open state file %s: %w", StateFile, err)
+	}
+	encoder := json.NewEncoder(file)
+
+	err = encoder.Encode(s)
+	if err != nil {
+		return fmt.Errorf("failed to encode state file %s: %w", StateFile, err)
+	}
+
+	return nil
+}
+
+func (s *State) DetectMismatches(
+	executor string,
+	params cue.Value,
+	root *os.Root,
+	inputs []string,
+) []string {
+	var mismatches []string
+	hasher := sha256.New()
+
+	if executor != s.Executor {
+		mismatches = append(mismatches, "executor")
+	}
+
+	paramsChecksum, err := hashParams(hasher, params)
+	if err != nil || !bytes.Equal(paramsChecksum, s.ParamsChecksum) {
+		mismatches = append(mismatches, "params-checksum")
+	}
+
+	if !reflect.DeepEqual(inputs, s.Inputs) {
+		mismatches = append(mismatches, "inputs")
+	}
+	inputsChecksum, err := hashFiles(hasher, nil, inputs)
+	if err != nil || !bytes.Equal(inputsChecksum, s.InputsChecksum) {
+		mismatches = append(mismatches, "inputs-checksum")
+	}
+
+	outputsChecksum, err := hashFiles(hasher, root, s.Outputs)
+	if err != nil || !bytes.Equal(outputsChecksum, s.OutputsChecksum) {
+		mismatches = append(mismatches, "outputs-checksum")
+	}
+
+	return mismatches
+}
+
+func hashParams(hasher hash.Hash, params cue.Value) ([]byte, error) {
+	paramsJSON, err := params.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal params to json: %w", err)
+	}
+
+	return hasher.Sum(paramsJSON), nil
+}
+
+func hashFiles(hasher hash.Hash, root *os.Root, files []string) ([]byte, error) {
+	var err error
+	for _, fileName := range files {
+		var file *os.File
+		var openErr error
+		if root != nil {
+			file, openErr = root.Open(fileName)
+		} else {
+			file, openErr = os.Open(fileName)
+		}
+		if multierr.AppendInto(&err, openErr) {
+			return nil, fmt.Errorf("failed to open input file %s: %w", fileName, err)
+		}
+
+		_, hashErr := io.Copy(hasher, file)
+		if multierr.AppendInto(&err, hashErr) {
+			return nil, fmt.Errorf("failed to hash input file %s: %w", fileName, err)
+		}
+	}
+
+	result := hasher.Sum(nil)
+	hasher.Reset()
+
+	return result, err
+}

--- a/plugins/k8s/kustomize/kustomize.go
+++ b/plugins/k8s/kustomize/kustomize.go
@@ -24,7 +24,7 @@ type Params struct {
 	Kustomization types.Kustomization `json:"-"`
 }
 
-func kustomize(_ context.Context, params *plugin.TaskParams[Params]) error {
+func kustomize(_ context.Context, params *plugin.TaskParams[Params]) ([]string, error) {
 	// Apply resources and any needed fixes
 	params.Params.Kustomization.Resources = params.Inputs
 	params.Params.Kustomization.FixKustomization()
@@ -32,23 +32,23 @@ func kustomize(_ context.Context, params *plugin.TaskParams[Params]) error {
 	// Write out the kustomization.yaml file
 	outFile, err := os.Create(path.Join(params.OutDir, konfig.DefaultKustomizationFileName()))
 	if err != nil {
-		return fmt.Errorf("failed to open kustomization file: %w", err)
+		return nil, fmt.Errorf("failed to open kustomization file: %w", err)
 	}
 
 	enc := yaml.NewEncoder(outFile)
 
 	err = enc.Encode(params.Params.Kustomization)
 	if err != nil {
-		return fmt.Errorf("failed to encode kustomization file as yaml: %w", err)
+		return nil, fmt.Errorf("failed to encode kustomization file as yaml: %w", err)
 	}
 
 	err = enc.Close()
 	if err != nil {
-		return fmt.Errorf("failed to close yaml encoder: %w", err)
+		return nil, fmt.Errorf("failed to close yaml encoder: %w", err)
 	}
 	err = outFile.Close()
 	if err != nil {
-		return fmt.Errorf("failed to close yaml file writer: %w", err)
+		return nil, fmt.Errorf("failed to close yaml file writer: %w", err)
 	}
 
 	// Perform the kustomization
@@ -58,30 +58,27 @@ func kustomize(_ context.Context, params *plugin.TaskParams[Params]) error {
 
 	res, err := kusty.Run(filesys.MakeFsOnDisk(), params.OutDir)
 	if err != nil {
-		return fmt.Errorf("failed to perform kustomization: %w", err)
+		return nil, fmt.Errorf("failed to perform kustomization: %w", err)
 	}
 
 	// Save the result
 	resYaml, err := res.AsYaml()
 	if err != nil {
-		return fmt.Errorf("failed to encode kustomized content as yaml: %w", err)
+		return nil, fmt.Errorf("failed to encode kustomized content as yaml: %w", err)
 	}
 
 	err = os.WriteFile(path.Join(params.OutDir, output), resYaml, 0o600)
 	if err != nil {
-		return fmt.Errorf("failed to write kustomized content to file: %w", err)
+		return nil, fmt.Errorf("failed to write kustomized content to file: %w", err)
 	}
 
-	return nil
+	return []string{output}, nil
 }
 
 func main() {
 	plugin.Serve(
 		plugin.NewExecutor(
 			"Kustomize",
-			[]string{
-				output,
-			},
 			kustomize,
 		),
 	)

--- a/plugins/k8s/resources/resources.go
+++ b/plugins/k8s/resources/resources.go
@@ -22,31 +22,28 @@ type Params struct {
 	Resources cue.Value `cue:"[...]" json:"resources"`
 }
 
-func genResources(_ context.Context, params *plugin.TaskParams[Params]) error {
+func genResources(_ context.Context, params *plugin.TaskParams[Params]) ([]string, error) {
 	if len(params.Inputs) > 0 {
-		return errors.New("resources task does not accept inputs")
+		return nil, errors.New("resources task does not accept inputs")
 	}
 
 	resourcesYaml, err := yaml.MarshalStream(params.Params.Resources)
 	if err != nil {
-		return fmt.Errorf("failed to marshal resources into yaml: %w", err)
+		return nil, fmt.Errorf("failed to marshal resources into yaml: %w", err)
 	}
 
 	err = os.WriteFile(path.Join(params.OutDir, output), []byte(resourcesYaml), 0o600)
 	if err != nil {
-		return fmt.Errorf("failed to write resources yaml to disk: %w", err)
+		return nil, fmt.Errorf("failed to write resources yaml to disk: %w", err)
 	}
 
-	return nil
+	return []string{output}, nil
 }
 
 func main() {
 	plugin.Serve(
 		plugin.NewExecutor(
 			"Resources",
-			[]string{
-				output,
-			},
 			genResources,
 		),
 	)

--- a/plugins/test/test.go
+++ b/plugins/test/test.go
@@ -16,11 +16,10 @@ type Params struct {
 
 var Executor_Test = plugin.NewExecutor(
 	"Test",
-	[]string{},
-	func(ctx context.Context, param *plugin.TaskParams[Params]) error {
+	func(ctx context.Context, param *plugin.TaskParams[Params]) ([]string, error) {
 		slog.InfoContext(ctx, "it's happening!", "thing", "value")
 
-		return nil
+		return nil, nil
 	},
 )
 

--- a/plugins/test/test_test.go
+++ b/plugins/test/test_test.go
@@ -19,7 +19,7 @@ func Test_Plugin(t *testing.T) {
 		Executor_Test,
 	)
 
-	err := executors.SendTask(
+	_, err := executors.SendTask(
 		t.Context(),
 		task.New(Executor_Test.Name, "testing", cue.Value{}),
 	)


### PR DESCRIPTION
Pipe outputs through from task execution back to the scheduler. This is now also used in task dirty state tracking.