### PR TITLE
feat: sessions

### DIFF
--- a/api/go/executor.go
+++ b/api/go/executor.go
@@ -17,6 +17,7 @@ import (
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/encoding/gocode/gocodec"
 
+	"github.com/google/uuid"
 	"github.com/spf13/afero"
 
 	goplugin "github.com/hashicorp/go-plugin"
@@ -119,6 +120,7 @@ func (s *executorGRPCServer) ExecuteTask(
 
 	tsk := task.Task{
 		ID: task.TaskId{
+			Session:  uuid.MustParse(req.GetSession()),
 			Name:     req.GetName(),
 			Executor: req.GetExecutor(),
 		},

--- a/api/go/executor.go
+++ b/api/go/executor.go
@@ -105,6 +105,20 @@ func (s *executorGRPCServer) DescribeExecutors(
 	return respBuilder.Build(), nil
 }
 
+func (s *executorGRPCServer) OpenSession(
+	ctx context.Context,
+	req *bonkv0.OpenSessionRequest,
+) (*bonkv0.OpenSessionResponse, error) {
+	return bonkv0.OpenSessionResponse_builder{}.Build(), nil
+}
+
+func (s *executorGRPCServer) CloseSession(
+	ctx context.Context,
+	req *bonkv0.CloseSessionRequest,
+) (*bonkv0.CloseSessionResponse, error) {
+	return bonkv0.CloseSessionResponse_builder{}.Build(), nil
+}
+
 func (s *executorGRPCServer) ExecuteTask(
 	ctx context.Context,
 	req *bonkv0.ExecuteTaskRequest,
@@ -120,7 +134,7 @@ func (s *executorGRPCServer) ExecuteTask(
 
 	tsk := task.Task{
 		ID: task.TaskId{
-			Session:  uuid.MustParse(req.GetSession()),
+			Session:  uuid.MustParse(req.GetSessionId()),
 			Name:     req.GetName(),
 			Executor: req.GetExecutor(),
 		},

--- a/api/proto/bonk/v0/executor.pb.go
+++ b/api/proto/bonk/v0/executor.pb.go
@@ -123,11 +123,12 @@ func (b0 DescribeExecutorsResponse_builder) Build() *DescribeExecutorsResponse {
 
 type ExecuteTaskRequest struct {
 	state                   protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name         *string                `protobuf:"bytes,1,opt,name=name"`
-	xxx_hidden_Executor     *string                `protobuf:"bytes,2,opt,name=executor"`
-	xxx_hidden_Inputs       []string               `protobuf:"bytes,3,rep,name=inputs"`
-	xxx_hidden_Parameters   *structpb.Struct       `protobuf:"bytes,4,opt,name=parameters"`
-	xxx_hidden_OutDirectory *string                `protobuf:"bytes,5,opt,name=out_directory,json=outDirectory"`
+	xxx_hidden_Session      *string                `protobuf:"bytes,1,opt,name=session"`
+	xxx_hidden_Name         *string                `protobuf:"bytes,2,opt,name=name"`
+	xxx_hidden_Executor     *string                `protobuf:"bytes,3,opt,name=executor"`
+	xxx_hidden_Inputs       []string               `protobuf:"bytes,4,rep,name=inputs"`
+	xxx_hidden_Parameters   *structpb.Struct       `protobuf:"bytes,5,opt,name=parameters"`
+	xxx_hidden_OutDirectory *string                `protobuf:"bytes,6,opt,name=out_directory,json=outDirectory"`
 	XXX_raceDetectHookData  protoimpl.RaceDetectHookData
 	XXX_presence            [1]uint32
 	unknownFields           protoimpl.UnknownFields
@@ -157,6 +158,16 @@ func (x *ExecuteTaskRequest) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
+}
+
+func (x *ExecuteTaskRequest) GetSession() string {
+	if x != nil {
+		if x.xxx_hidden_Session != nil {
+			return *x.xxx_hidden_Session
+		}
+		return ""
+	}
+	return ""
 }
 
 func (x *ExecuteTaskRequest) GetName() string {
@@ -203,14 +214,19 @@ func (x *ExecuteTaskRequest) GetOutDirectory() string {
 	return ""
 }
 
+func (x *ExecuteTaskRequest) SetSession(v string) {
+	x.xxx_hidden_Session = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 6)
+}
+
 func (x *ExecuteTaskRequest) SetName(v string) {
 	x.xxx_hidden_Name = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 5)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 6)
 }
 
 func (x *ExecuteTaskRequest) SetExecutor(v string) {
 	x.xxx_hidden_Executor = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 5)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 6)
 }
 
 func (x *ExecuteTaskRequest) SetInputs(v []string) {
@@ -223,21 +239,28 @@ func (x *ExecuteTaskRequest) SetParameters(v *structpb.Struct) {
 
 func (x *ExecuteTaskRequest) SetOutDirectory(v string) {
 	x.xxx_hidden_OutDirectory = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 5)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 6)
 }
 
-func (x *ExecuteTaskRequest) HasName() bool {
+func (x *ExecuteTaskRequest) HasSession() bool {
 	if x == nil {
 		return false
 	}
 	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
 }
 
-func (x *ExecuteTaskRequest) HasExecutor() bool {
+func (x *ExecuteTaskRequest) HasName() bool {
 	if x == nil {
 		return false
 	}
 	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *ExecuteTaskRequest) HasExecutor() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 2)
 }
 
 func (x *ExecuteTaskRequest) HasParameters() bool {
@@ -251,16 +274,21 @@ func (x *ExecuteTaskRequest) HasOutDirectory() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 4)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 5)
+}
+
+func (x *ExecuteTaskRequest) ClearSession() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_Session = nil
 }
 
 func (x *ExecuteTaskRequest) ClearName() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
 	x.xxx_hidden_Name = nil
 }
 
 func (x *ExecuteTaskRequest) ClearExecutor() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 2)
 	x.xxx_hidden_Executor = nil
 }
 
@@ -269,13 +297,14 @@ func (x *ExecuteTaskRequest) ClearParameters() {
 }
 
 func (x *ExecuteTaskRequest) ClearOutDirectory() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 4)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 5)
 	x.xxx_hidden_OutDirectory = nil
 }
 
 type ExecuteTaskRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	Session      *string
 	Name         *string
 	Executor     *string
 	Inputs       []string
@@ -287,18 +316,22 @@ func (b0 ExecuteTaskRequest_builder) Build() *ExecuteTaskRequest {
 	m0 := &ExecuteTaskRequest{}
 	b, x := &b0, m0
 	_, _ = b, x
+	if b.Session != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 6)
+		x.xxx_hidden_Session = b.Session
+	}
 	if b.Name != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 5)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 6)
 		x.xxx_hidden_Name = b.Name
 	}
 	if b.Executor != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 5)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 6)
 		x.xxx_hidden_Executor = b.Executor
 	}
 	x.xxx_hidden_Inputs = b.Inputs
 	x.xxx_hidden_Parameters = b.Parameters
 	if b.OutDirectory != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 5)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 6)
 		x.xxx_hidden_OutDirectory = b.OutDirectory
 	}
 	return m0
@@ -581,15 +614,16 @@ const file_bonk_v0_executor_proto_rawDesc = "" +
 	"\x13ExecutorDescription\x1at\n" +
 	"\x0eExecutorsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12L\n" +
-	"\x05value\x18\x02 \x01(\v26.bonk.v0.DescribeExecutorsResponse.ExecutorDescriptionR\x05value:\x028\x01\"\xba\x01\n" +
-	"\x12ExecuteTaskRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
-	"\bexecutor\x18\x02 \x01(\tR\bexecutor\x12\x16\n" +
-	"\x06inputs\x18\x03 \x03(\tR\x06inputs\x127\n" +
+	"\x05value\x18\x02 \x01(\v26.bonk.v0.DescribeExecutorsResponse.ExecutorDescriptionR\x05value:\x028\x01\"\xd4\x01\n" +
+	"\x12ExecuteTaskRequest\x12\x18\n" +
+	"\asession\x18\x01 \x01(\tR\asession\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1a\n" +
+	"\bexecutor\x18\x03 \x01(\tR\bexecutor\x12\x16\n" +
+	"\x06inputs\x18\x04 \x03(\tR\x06inputs\x127\n" +
 	"\n" +
-	"parameters\x18\x04 \x01(\v2\x17.google.protobuf.StructR\n" +
+	"parameters\x18\x05 \x01(\v2\x17.google.protobuf.StructR\n" +
 	"parameters\x12#\n" +
-	"\rout_directory\x18\x05 \x01(\tR\foutDirectory\"\x91\x02\n" +
+	"\rout_directory\x18\x06 \x01(\tR\foutDirectory\"\x91\x02\n" +
 	"\x13ExecuteTaskResponse\x12\x16\n" +
 	"\x06output\x18\x01 \x03(\tR\x06output\x12P\n" +
 	"\x0efollowup_tasks\x18\x02 \x03(\v2).bonk.v0.ExecuteTaskResponse.FollowupTaskR\rfollowupTasks\x1a\x8f\x01\n" +

--- a/api/proto/bonk/v0/executor.pb.go
+++ b/api/proto/bonk/v0/executor.pb.go
@@ -121,9 +121,251 @@ func (b0 DescribeExecutorsResponse_builder) Build() *DescribeExecutorsResponse {
 	return m0
 }
 
+type OpenSessionRequest struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_SessionId   *string                `protobuf:"bytes,1,opt,name=session_id,json=sessionId"`
+	XXX_raceDetectHookData protoimpl.RaceDetectHookData
+	XXX_presence           [1]uint32
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *OpenSessionRequest) Reset() {
+	*x = OpenSessionRequest{}
+	mi := &file_bonk_v0_executor_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpenSessionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpenSessionRequest) ProtoMessage() {}
+
+func (x *OpenSessionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bonk_v0_executor_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *OpenSessionRequest) GetSessionId() string {
+	if x != nil {
+		if x.xxx_hidden_SessionId != nil {
+			return *x.xxx_hidden_SessionId
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *OpenSessionRequest) SetSessionId(v string) {
+	x.xxx_hidden_SessionId = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 1)
+}
+
+func (x *OpenSessionRequest) HasSessionId() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
+}
+
+func (x *OpenSessionRequest) ClearSessionId() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_SessionId = nil
+}
+
+type OpenSessionRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	SessionId *string
+}
+
+func (b0 OpenSessionRequest_builder) Build() *OpenSessionRequest {
+	m0 := &OpenSessionRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.SessionId != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 1)
+		x.xxx_hidden_SessionId = b.SessionId
+	}
+	return m0
+}
+
+type OpenSessionResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OpenSessionResponse) Reset() {
+	*x = OpenSessionResponse{}
+	mi := &file_bonk_v0_executor_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpenSessionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpenSessionResponse) ProtoMessage() {}
+
+func (x *OpenSessionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bonk_v0_executor_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type OpenSessionResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 OpenSessionResponse_builder) Build() *OpenSessionResponse {
+	m0 := &OpenSessionResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type CloseSessionRequest struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_SessionId   *string                `protobuf:"bytes,1,opt,name=session_id,json=sessionId"`
+	XXX_raceDetectHookData protoimpl.RaceDetectHookData
+	XXX_presence           [1]uint32
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *CloseSessionRequest) Reset() {
+	*x = CloseSessionRequest{}
+	mi := &file_bonk_v0_executor_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CloseSessionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CloseSessionRequest) ProtoMessage() {}
+
+func (x *CloseSessionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bonk_v0_executor_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *CloseSessionRequest) GetSessionId() string {
+	if x != nil {
+		if x.xxx_hidden_SessionId != nil {
+			return *x.xxx_hidden_SessionId
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *CloseSessionRequest) SetSessionId(v string) {
+	x.xxx_hidden_SessionId = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 1)
+}
+
+func (x *CloseSessionRequest) HasSessionId() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
+}
+
+func (x *CloseSessionRequest) ClearSessionId() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_SessionId = nil
+}
+
+type CloseSessionRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	SessionId *string
+}
+
+func (b0 CloseSessionRequest_builder) Build() *CloseSessionRequest {
+	m0 := &CloseSessionRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.SessionId != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 1)
+		x.xxx_hidden_SessionId = b.SessionId
+	}
+	return m0
+}
+
+type CloseSessionResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CloseSessionResponse) Reset() {
+	*x = CloseSessionResponse{}
+	mi := &file_bonk_v0_executor_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CloseSessionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CloseSessionResponse) ProtoMessage() {}
+
+func (x *CloseSessionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bonk_v0_executor_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type CloseSessionResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 CloseSessionResponse_builder) Build() *CloseSessionResponse {
+	m0 := &CloseSessionResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 type ExecuteTaskRequest struct {
 	state                   protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Session      *string                `protobuf:"bytes,1,opt,name=session"`
+	xxx_hidden_SessionId    *string                `protobuf:"bytes,1,opt,name=session_id,json=sessionId"`
 	xxx_hidden_Name         *string                `protobuf:"bytes,2,opt,name=name"`
 	xxx_hidden_Executor     *string                `protobuf:"bytes,3,opt,name=executor"`
 	xxx_hidden_Inputs       []string               `protobuf:"bytes,4,rep,name=inputs"`
@@ -137,7 +379,7 @@ type ExecuteTaskRequest struct {
 
 func (x *ExecuteTaskRequest) Reset() {
 	*x = ExecuteTaskRequest{}
-	mi := &file_bonk_v0_executor_proto_msgTypes[2]
+	mi := &file_bonk_v0_executor_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -149,7 +391,7 @@ func (x *ExecuteTaskRequest) String() string {
 func (*ExecuteTaskRequest) ProtoMessage() {}
 
 func (x *ExecuteTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bonk_v0_executor_proto_msgTypes[2]
+	mi := &file_bonk_v0_executor_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -160,10 +402,10 @@ func (x *ExecuteTaskRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *ExecuteTaskRequest) GetSession() string {
+func (x *ExecuteTaskRequest) GetSessionId() string {
 	if x != nil {
-		if x.xxx_hidden_Session != nil {
-			return *x.xxx_hidden_Session
+		if x.xxx_hidden_SessionId != nil {
+			return *x.xxx_hidden_SessionId
 		}
 		return ""
 	}
@@ -214,8 +456,8 @@ func (x *ExecuteTaskRequest) GetOutDirectory() string {
 	return ""
 }
 
-func (x *ExecuteTaskRequest) SetSession(v string) {
-	x.xxx_hidden_Session = &v
+func (x *ExecuteTaskRequest) SetSessionId(v string) {
+	x.xxx_hidden_SessionId = &v
 	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 6)
 }
 
@@ -242,7 +484,7 @@ func (x *ExecuteTaskRequest) SetOutDirectory(v string) {
 	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 6)
 }
 
-func (x *ExecuteTaskRequest) HasSession() bool {
+func (x *ExecuteTaskRequest) HasSessionId() bool {
 	if x == nil {
 		return false
 	}
@@ -277,9 +519,9 @@ func (x *ExecuteTaskRequest) HasOutDirectory() bool {
 	return protoimpl.X.Present(&(x.XXX_presence[0]), 5)
 }
 
-func (x *ExecuteTaskRequest) ClearSession() {
+func (x *ExecuteTaskRequest) ClearSessionId() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
-	x.xxx_hidden_Session = nil
+	x.xxx_hidden_SessionId = nil
 }
 
 func (x *ExecuteTaskRequest) ClearName() {
@@ -304,7 +546,7 @@ func (x *ExecuteTaskRequest) ClearOutDirectory() {
 type ExecuteTaskRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Session      *string
+	SessionId    *string
 	Name         *string
 	Executor     *string
 	Inputs       []string
@@ -316,9 +558,9 @@ func (b0 ExecuteTaskRequest_builder) Build() *ExecuteTaskRequest {
 	m0 := &ExecuteTaskRequest{}
 	b, x := &b0, m0
 	_, _ = b, x
-	if b.Session != nil {
+	if b.SessionId != nil {
 		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 6)
-		x.xxx_hidden_Session = b.Session
+		x.xxx_hidden_SessionId = b.SessionId
 	}
 	if b.Name != nil {
 		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 6)
@@ -347,7 +589,7 @@ type ExecuteTaskResponse struct {
 
 func (x *ExecuteTaskResponse) Reset() {
 	*x = ExecuteTaskResponse{}
-	mi := &file_bonk_v0_executor_proto_msgTypes[3]
+	mi := &file_bonk_v0_executor_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -359,7 +601,7 @@ func (x *ExecuteTaskResponse) String() string {
 func (*ExecuteTaskResponse) ProtoMessage() {}
 
 func (x *ExecuteTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bonk_v0_executor_proto_msgTypes[3]
+	mi := &file_bonk_v0_executor_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -418,7 +660,7 @@ type DescribeExecutorsResponse_ExecutorDescription struct {
 
 func (x *DescribeExecutorsResponse_ExecutorDescription) Reset() {
 	*x = DescribeExecutorsResponse_ExecutorDescription{}
-	mi := &file_bonk_v0_executor_proto_msgTypes[4]
+	mi := &file_bonk_v0_executor_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -430,7 +672,7 @@ func (x *DescribeExecutorsResponse_ExecutorDescription) String() string {
 func (*DescribeExecutorsResponse_ExecutorDescription) ProtoMessage() {}
 
 func (x *DescribeExecutorsResponse_ExecutorDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_bonk_v0_executor_proto_msgTypes[4]
+	mi := &file_bonk_v0_executor_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -467,7 +709,7 @@ type ExecuteTaskResponse_FollowupTask struct {
 
 func (x *ExecuteTaskResponse_FollowupTask) Reset() {
 	*x = ExecuteTaskResponse_FollowupTask{}
-	mi := &file_bonk_v0_executor_proto_msgTypes[6]
+	mi := &file_bonk_v0_executor_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -479,7 +721,7 @@ func (x *ExecuteTaskResponse_FollowupTask) String() string {
 func (*ExecuteTaskResponse_FollowupTask) ProtoMessage() {}
 
 func (x *ExecuteTaskResponse_FollowupTask) ProtoReflect() protoreflect.Message {
-	mi := &file_bonk_v0_executor_proto_msgTypes[6]
+	mi := &file_bonk_v0_executor_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -614,9 +856,18 @@ const file_bonk_v0_executor_proto_rawDesc = "" +
 	"\x13ExecutorDescription\x1at\n" +
 	"\x0eExecutorsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12L\n" +
-	"\x05value\x18\x02 \x01(\v26.bonk.v0.DescribeExecutorsResponse.ExecutorDescriptionR\x05value:\x028\x01\"\xd4\x01\n" +
-	"\x12ExecuteTaskRequest\x12\x18\n" +
-	"\asession\x18\x01 \x01(\tR\asession\x12\x12\n" +
+	"\x05value\x18\x02 \x01(\v26.bonk.v0.DescribeExecutorsResponse.ExecutorDescriptionR\x05value:\x028\x01\"3\n" +
+	"\x12OpenSessionRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\x15\n" +
+	"\x13OpenSessionResponse\"4\n" +
+	"\x13CloseSessionRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\x16\n" +
+	"\x14CloseSessionResponse\"\xd9\x01\n" +
+	"\x12ExecuteTaskRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1a\n" +
 	"\bexecutor\x18\x03 \x01(\tR\bexecutor\x12\x16\n" +
 	"\x06inputs\x18\x04 \x03(\tR\x06inputs\x127\n" +
@@ -633,38 +884,48 @@ const file_bonk_v0_executor_proto_rawDesc = "" +
 	"\x06inputs\x18\x03 \x03(\tR\x06inputs\x127\n" +
 	"\n" +
 	"parameters\x18\x04 \x01(\v2\x17.google.protobuf.StructR\n" +
-	"parameters2\xb7\x01\n" +
+	"parameters2\xce\x02\n" +
 	"\x0fExecutorService\x12Z\n" +
 	"\x11DescribeExecutors\x12!.bonk.v0.DescribeExecutorsRequest\x1a\".bonk.v0.DescribeExecutorsResponse\x12H\n" +
+	"\vOpenSession\x12\x1b.bonk.v0.OpenSessionRequest\x1a\x1c.bonk.v0.OpenSessionResponse\x12K\n" +
+	"\fCloseSession\x12\x1c.bonk.v0.CloseSessionRequest\x1a\x1d.bonk.v0.CloseSessionResponse\x12H\n" +
 	"\vExecuteTask\x12\x1b.bonk.v0.ExecuteTaskRequest\x1a\x1c.bonk.v0.ExecuteTaskResponseB}\n" +
 	"\vcom.bonk.v0B\rExecutorProtoP\x01Z\"go.bonk.build/api/go/proto/bonk/v0\xa2\x02\x03BVX\xaa\x02\aBonk.V0\xca\x02\aBonk\\V0\xe2\x02\x13Bonk\\V0\\GPBMetadata\xea\x02\bBonk::V0b\beditionsp\xe8\a"
 
-var file_bonk_v0_executor_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_bonk_v0_executor_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_bonk_v0_executor_proto_goTypes = []any{
 	(*DescribeExecutorsRequest)(nil),                      // 0: bonk.v0.DescribeExecutorsRequest
 	(*DescribeExecutorsResponse)(nil),                     // 1: bonk.v0.DescribeExecutorsResponse
-	(*ExecuteTaskRequest)(nil),                            // 2: bonk.v0.ExecuteTaskRequest
-	(*ExecuteTaskResponse)(nil),                           // 3: bonk.v0.ExecuteTaskResponse
-	(*DescribeExecutorsResponse_ExecutorDescription)(nil), // 4: bonk.v0.DescribeExecutorsResponse.ExecutorDescription
-	nil,                                      // 5: bonk.v0.DescribeExecutorsResponse.ExecutorsEntry
-	(*ExecuteTaskResponse_FollowupTask)(nil), // 6: bonk.v0.ExecuteTaskResponse.FollowupTask
-	(*structpb.Struct)(nil),                  // 7: google.protobuf.Struct
+	(*OpenSessionRequest)(nil),                            // 2: bonk.v0.OpenSessionRequest
+	(*OpenSessionResponse)(nil),                           // 3: bonk.v0.OpenSessionResponse
+	(*CloseSessionRequest)(nil),                           // 4: bonk.v0.CloseSessionRequest
+	(*CloseSessionResponse)(nil),                          // 5: bonk.v0.CloseSessionResponse
+	(*ExecuteTaskRequest)(nil),                            // 6: bonk.v0.ExecuteTaskRequest
+	(*ExecuteTaskResponse)(nil),                           // 7: bonk.v0.ExecuteTaskResponse
+	(*DescribeExecutorsResponse_ExecutorDescription)(nil), // 8: bonk.v0.DescribeExecutorsResponse.ExecutorDescription
+	nil,                                      // 9: bonk.v0.DescribeExecutorsResponse.ExecutorsEntry
+	(*ExecuteTaskResponse_FollowupTask)(nil), // 10: bonk.v0.ExecuteTaskResponse.FollowupTask
+	(*structpb.Struct)(nil),                  // 11: google.protobuf.Struct
 }
 var file_bonk_v0_executor_proto_depIdxs = []int32{
-	5, // 0: bonk.v0.DescribeExecutorsResponse.executors:type_name -> bonk.v0.DescribeExecutorsResponse.ExecutorsEntry
-	7, // 1: bonk.v0.ExecuteTaskRequest.parameters:type_name -> google.protobuf.Struct
-	6, // 2: bonk.v0.ExecuteTaskResponse.followup_tasks:type_name -> bonk.v0.ExecuteTaskResponse.FollowupTask
-	4, // 3: bonk.v0.DescribeExecutorsResponse.ExecutorsEntry.value:type_name -> bonk.v0.DescribeExecutorsResponse.ExecutorDescription
-	7, // 4: bonk.v0.ExecuteTaskResponse.FollowupTask.parameters:type_name -> google.protobuf.Struct
-	0, // 5: bonk.v0.ExecutorService.DescribeExecutors:input_type -> bonk.v0.DescribeExecutorsRequest
-	2, // 6: bonk.v0.ExecutorService.ExecuteTask:input_type -> bonk.v0.ExecuteTaskRequest
-	1, // 7: bonk.v0.ExecutorService.DescribeExecutors:output_type -> bonk.v0.DescribeExecutorsResponse
-	3, // 8: bonk.v0.ExecutorService.ExecuteTask:output_type -> bonk.v0.ExecuteTaskResponse
-	7, // [7:9] is the sub-list for method output_type
-	5, // [5:7] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	9,  // 0: bonk.v0.DescribeExecutorsResponse.executors:type_name -> bonk.v0.DescribeExecutorsResponse.ExecutorsEntry
+	11, // 1: bonk.v0.ExecuteTaskRequest.parameters:type_name -> google.protobuf.Struct
+	10, // 2: bonk.v0.ExecuteTaskResponse.followup_tasks:type_name -> bonk.v0.ExecuteTaskResponse.FollowupTask
+	8,  // 3: bonk.v0.DescribeExecutorsResponse.ExecutorsEntry.value:type_name -> bonk.v0.DescribeExecutorsResponse.ExecutorDescription
+	11, // 4: bonk.v0.ExecuteTaskResponse.FollowupTask.parameters:type_name -> google.protobuf.Struct
+	0,  // 5: bonk.v0.ExecutorService.DescribeExecutors:input_type -> bonk.v0.DescribeExecutorsRequest
+	2,  // 6: bonk.v0.ExecutorService.OpenSession:input_type -> bonk.v0.OpenSessionRequest
+	4,  // 7: bonk.v0.ExecutorService.CloseSession:input_type -> bonk.v0.CloseSessionRequest
+	6,  // 8: bonk.v0.ExecutorService.ExecuteTask:input_type -> bonk.v0.ExecuteTaskRequest
+	1,  // 9: bonk.v0.ExecutorService.DescribeExecutors:output_type -> bonk.v0.DescribeExecutorsResponse
+	3,  // 10: bonk.v0.ExecutorService.OpenSession:output_type -> bonk.v0.OpenSessionResponse
+	5,  // 11: bonk.v0.ExecutorService.CloseSession:output_type -> bonk.v0.CloseSessionResponse
+	7,  // 12: bonk.v0.ExecutorService.ExecuteTask:output_type -> bonk.v0.ExecuteTaskResponse
+	9,  // [9:13] is the sub-list for method output_type
+	5,  // [5:9] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_bonk_v0_executor_proto_init() }
@@ -678,7 +939,7 @@ func file_bonk_v0_executor_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bonk_v0_executor_proto_rawDesc), len(file_bonk_v0_executor_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/bonk/v0/executor.proto
+++ b/api/proto/bonk/v0/executor.proto
@@ -15,11 +15,12 @@ message DescribeExecutorsResponse {
 }
 
 message ExecuteTaskRequest {
-  string name = 1;
-  string executor = 2;
-  repeated string inputs = 3;
-  google.protobuf.Struct parameters = 4;
-  string out_directory = 5;
+  string session = 1;
+  string name = 2;
+  string executor = 3;
+  repeated string inputs = 4;
+  google.protobuf.Struct parameters = 5;
+  string out_directory = 6;
 }
 
 message ExecuteTaskResponse {

--- a/api/proto/bonk/v0/executor.proto
+++ b/api/proto/bonk/v0/executor.proto
@@ -14,8 +14,20 @@ message DescribeExecutorsResponse {
   map<string, ExecutorDescription> executors = 1;
 }
 
+message OpenSessionRequest {
+  string session_id = 1;
+}
+
+message OpenSessionResponse {}
+
+message CloseSessionRequest {
+  string session_id = 1;
+}
+
+message CloseSessionResponse {}
+
 message ExecuteTaskRequest {
-  string session = 1;
+  string session_id = 1;
   string name = 2;
   string executor = 3;
   repeated string inputs = 4;
@@ -38,6 +50,10 @@ message ExecuteTaskResponse {
 service ExecutorService {
   // General plugin support
   rpc DescribeExecutors(DescribeExecutorsRequest) returns (DescribeExecutorsResponse);
+
+  // Used for opening & closing sessions
+  rpc OpenSession(OpenSessionRequest) returns (OpenSessionResponse);
+  rpc CloseSession(CloseSessionRequest) returns (CloseSessionResponse);
 
   // Executor interface
   rpc ExecuteTask(ExecuteTaskRequest) returns (ExecuteTaskResponse);

--- a/api/proto/bonk/v0/executor_grpc.pb.go
+++ b/api/proto/bonk/v0/executor_grpc.pb.go
@@ -20,6 +20,8 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	ExecutorService_DescribeExecutors_FullMethodName = "/bonk.v0.ExecutorService/DescribeExecutors"
+	ExecutorService_OpenSession_FullMethodName       = "/bonk.v0.ExecutorService/OpenSession"
+	ExecutorService_CloseSession_FullMethodName      = "/bonk.v0.ExecutorService/CloseSession"
 	ExecutorService_ExecuteTask_FullMethodName       = "/bonk.v0.ExecutorService/ExecuteTask"
 )
 
@@ -29,6 +31,9 @@ const (
 type ExecutorServiceClient interface {
 	// General plugin support
 	DescribeExecutors(ctx context.Context, in *DescribeExecutorsRequest, opts ...grpc.CallOption) (*DescribeExecutorsResponse, error)
+	// Used for opening & closing sessions
+	OpenSession(ctx context.Context, in *OpenSessionRequest, opts ...grpc.CallOption) (*OpenSessionResponse, error)
+	CloseSession(ctx context.Context, in *CloseSessionRequest, opts ...grpc.CallOption) (*CloseSessionResponse, error)
 	// Executor interface
 	ExecuteTask(ctx context.Context, in *ExecuteTaskRequest, opts ...grpc.CallOption) (*ExecuteTaskResponse, error)
 }
@@ -51,6 +56,26 @@ func (c *executorServiceClient) DescribeExecutors(ctx context.Context, in *Descr
 	return out, nil
 }
 
+func (c *executorServiceClient) OpenSession(ctx context.Context, in *OpenSessionRequest, opts ...grpc.CallOption) (*OpenSessionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(OpenSessionResponse)
+	err := c.cc.Invoke(ctx, ExecutorService_OpenSession_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *executorServiceClient) CloseSession(ctx context.Context, in *CloseSessionRequest, opts ...grpc.CallOption) (*CloseSessionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CloseSessionResponse)
+	err := c.cc.Invoke(ctx, ExecutorService_CloseSession_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *executorServiceClient) ExecuteTask(ctx context.Context, in *ExecuteTaskRequest, opts ...grpc.CallOption) (*ExecuteTaskResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ExecuteTaskResponse)
@@ -67,6 +92,9 @@ func (c *executorServiceClient) ExecuteTask(ctx context.Context, in *ExecuteTask
 type ExecutorServiceServer interface {
 	// General plugin support
 	DescribeExecutors(context.Context, *DescribeExecutorsRequest) (*DescribeExecutorsResponse, error)
+	// Used for opening & closing sessions
+	OpenSession(context.Context, *OpenSessionRequest) (*OpenSessionResponse, error)
+	CloseSession(context.Context, *CloseSessionRequest) (*CloseSessionResponse, error)
 	// Executor interface
 	ExecuteTask(context.Context, *ExecuteTaskRequest) (*ExecuteTaskResponse, error)
 	mustEmbedUnimplementedExecutorServiceServer()
@@ -81,6 +109,12 @@ type UnimplementedExecutorServiceServer struct{}
 
 func (UnimplementedExecutorServiceServer) DescribeExecutors(context.Context, *DescribeExecutorsRequest) (*DescribeExecutorsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DescribeExecutors not implemented")
+}
+func (UnimplementedExecutorServiceServer) OpenSession(context.Context, *OpenSessionRequest) (*OpenSessionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method OpenSession not implemented")
+}
+func (UnimplementedExecutorServiceServer) CloseSession(context.Context, *CloseSessionRequest) (*CloseSessionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CloseSession not implemented")
 }
 func (UnimplementedExecutorServiceServer) ExecuteTask(context.Context, *ExecuteTaskRequest) (*ExecuteTaskResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExecuteTask not implemented")
@@ -124,6 +158,42 @@ func _ExecutorService_DescribeExecutors_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ExecutorService_OpenSession_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(OpenSessionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ExecutorServiceServer).OpenSession(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ExecutorService_OpenSession_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ExecutorServiceServer).OpenSession(ctx, req.(*OpenSessionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ExecutorService_CloseSession_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CloseSessionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ExecutorServiceServer).CloseSession(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ExecutorService_CloseSession_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ExecutorServiceServer).CloseSession(ctx, req.(*CloseSessionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ExecutorService_ExecuteTask_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ExecuteTaskRequest)
 	if err := dec(in); err != nil {
@@ -152,6 +222,14 @@ var ExecutorService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DescribeExecutors",
 			Handler:    _ExecutorService_DescribeExecutors_Handler,
+		},
+		{
+			MethodName: "OpenSession",
+			Handler:    _ExecutorService_OpenSession_Handler,
+		},
+		{
+			MethodName: "CloseSession",
+			Handler:    _ExecutorService_CloseSession_Handler,
 		},
 		{
 			MethodName: "ExecuteTask",

--- a/cmd/bonk/main.go
+++ b/cmd/bonk/main.go
@@ -45,8 +45,7 @@ var rootCmd = &cobra.Command{
 		pum := plugin.NewPluginManager(&bem)
 		defer pum.Shutdown()
 
-		sched := scheduler.NewScheduler(project, &bem, concurrency)
-		defer sched.Run()
+		sched := scheduler.NewScheduler(project, &bem, pum, concurrency)
 
 		plugins := []string{
 			"go.bonk.build/plugins/test",
@@ -60,7 +59,7 @@ var rootCmd = &cobra.Command{
 		}
 		cobra.CheckErr(err)
 
-		err = multierr.Combine(
+		cobra.CheckErr(multierr.Combine(
 			sched.AddTask(
 				task.New(
 					"test:Test",
@@ -89,8 +88,9 @@ var rootCmd = &cobra.Command{
 				),
 				"Test.Resources:resources:Resources",
 			),
-		)
+		))
 
+		err = sched.Run(cmd.Context())
 		cobra.CheckErr(err)
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	cuelang.org/go v0.14.1
 	github.com/ValerySidorin/shclog v0.0.1
 	github.com/delicb/slogbuffer v0.1.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/noneback/go-taskflow v1.1.3
 	github.com/pterm/pterm v0.12.81
@@ -90,7 +91,6 @@ require (
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gookit/color v1.5.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect

--- a/pkg/executor/rpc.go
+++ b/pkg/executor/rpc.go
@@ -28,8 +28,10 @@ type rpcExecutor struct {
 }
 
 func (pb *rpcExecutor) Execute(ctx context.Context, tsk task.Task, result *task.Result) error {
+	session := tsk.ID.Session.String()
 	outDir := tsk.ID.GetOutputDirectory()
 	taskReqBuilder := bonkv0.ExecuteTaskRequest_builder{
+		Session:      &session,
 		Name:         &tsk.ID.Name,
 		Executor:     &pb.name,
 		Inputs:       tsk.Inputs,

--- a/pkg/executor/rpc.go
+++ b/pkg/executor/rpc.go
@@ -28,10 +28,10 @@ type rpcExecutor struct {
 }
 
 func (pb *rpcExecutor) Execute(ctx context.Context, tsk task.Task, result *task.Result) error {
-	session := tsk.ID.Session.String()
+	sessionIdStr := tsk.ID.Session.String()
 	outDir := tsk.ID.GetOutputDirectory()
 	taskReqBuilder := bonkv0.ExecuteTaskRequest_builder{
-		Session:      &session,
+		SessionId:    &sessionIdStr,
 		Name:         &tsk.ID.Name,
 		Executor:     &pb.name,
 		Inputs:       tsk.Inputs,

--- a/pkg/executor/rpc.go
+++ b/pkg/executor/rpc.go
@@ -6,10 +6,13 @@ package executor // import "go.bonk.build/pkg/executor"
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"go.uber.org/multierr"
 
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/google/uuid"
 
 	bonkv0 "go.bonk.build/api/proto/bonk/v0"
 	"go.bonk.build/pkg/task"
@@ -25,6 +28,37 @@ func NewRPC(name string, client bonkv0.ExecutorServiceClient) Executor {
 type rpcExecutor struct {
 	name   string
 	client bonkv0.ExecutorServiceClient
+}
+
+var (
+	_ Executor       = (*rpcExecutor)(nil)
+	_ SessionManager = (*rpcExecutor)(nil)
+)
+
+func (pb *rpcExecutor) OpenSession(ctx context.Context, sessionId uuid.UUID) error {
+	sessionIdString := sessionId.String()
+	_, err := pb.client.OpenSession(ctx, bonkv0.OpenSessionRequest_builder{
+		SessionId: &sessionIdString,
+	}.Build())
+
+	return fmt.Errorf("failed to open session with executor: %w", err)
+}
+
+func (pb *rpcExecutor) CloseSession(ctx context.Context, sessionId uuid.UUID) {
+	sessionIdString := sessionId.String()
+	_, err := pb.client.CloseSession(ctx, bonkv0.CloseSessionRequest_builder{
+		SessionId: &sessionIdString,
+	}.Build())
+	if err != nil {
+		slog.WarnContext(
+			ctx,
+			"error returned when closing session",
+			"plugin",
+			pb.name,
+			"session",
+			sessionId.String(),
+		)
+	}
 }
 
 func (pb *rpcExecutor) Execute(ctx context.Context, tsk task.Task, result *task.Result) error {

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/ValerySidorin/shclog"
+	"github.com/google/uuid"
 
 	goplugin "github.com/hashicorp/go-plugin"
 
@@ -85,6 +86,38 @@ func (pm *PluginManager) StartPlugin(ctx context.Context, pluginPath string) err
 	}
 
 	return nil
+}
+
+func (pm *PluginManager) OpenSession(ctx context.Context, sessionId uuid.UUID) error {
+	var err error
+	sessionIdString := sessionId.String()
+	for _, plugin := range pm.plugins {
+		_, openErr := plugin.executorClient.OpenSession(ctx, bonkv0.OpenSessionRequest_builder{
+			SessionId: &sessionIdString,
+		}.Build())
+		multierr.AppendInto(&err, openErr)
+	}
+
+	return err
+}
+
+func (pm *PluginManager) CloseSession(ctx context.Context, sessionId uuid.UUID) {
+	sessionIdString := sessionId.String()
+	for name, plugin := range pm.plugins {
+		_, err := plugin.executorClient.CloseSession(ctx, bonkv0.CloseSessionRequest_builder{
+			SessionId: &sessionIdString,
+		}.Build())
+		if err != nil {
+			slog.WarnContext(
+				ctx,
+				"error returned when closing session",
+				"plugin",
+				name,
+				"session",
+				sessionId.String(),
+			)
+		}
+	}
 }
 
 func (pm *PluginManager) Shutdown() {

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -101,25 +101,6 @@ func (pm *PluginManager) OpenSession(ctx context.Context, sessionId uuid.UUID) e
 	return err
 }
 
-func (pm *PluginManager) CloseSession(ctx context.Context, sessionId uuid.UUID) {
-	sessionIdString := sessionId.String()
-	for name, plugin := range pm.plugins {
-		_, err := plugin.executorClient.CloseSession(ctx, bonkv0.CloseSessionRequest_builder{
-			SessionId: &sessionIdString,
-		}.Build())
-		if err != nil {
-			slog.WarnContext(
-				ctx,
-				"error returned when closing session",
-				"plugin",
-				name,
-				"session",
-				sessionId.String(),
-			)
-		}
-	}
-}
-
 func (pm *PluginManager) Shutdown() {
 	for pluginName, plugin := range pm.plugins {
 		for executorName := range plugin.executors {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -10,7 +10,6 @@ import (
 
 	"go.uber.org/multierr"
 
-	"github.com/google/uuid"
 	"github.com/spf13/afero"
 
 	gotaskflow "github.com/noneback/go-taskflow"
@@ -22,33 +21,19 @@ type TaskSender interface {
 	Execute(ctx context.Context, tsk task.Task, result *task.Result) error
 }
 
-type SessionManager interface {
-	OpenSession(ctx context.Context, sessionId uuid.UUID) error
-	CloseSession(ctx context.Context, sessionId uuid.UUID)
-}
-
 type Scheduler struct {
 	project afero.Fs
 
 	executorManager TaskSender
-	sessionManager  SessionManager
 	executor        gotaskflow.Executor
 	tasks           map[string]*gotaskflow.Task
 	rootFlow        *gotaskflow.TaskFlow
-
-	sessionId uuid.UUID
 }
 
-func NewScheduler(
-	project afero.Fs,
-	executorManager TaskSender,
-	sessionManager SessionManager,
-	concurrency uint,
-) *Scheduler {
+func NewScheduler(project afero.Fs, executorManager TaskSender, concurrency uint) *Scheduler {
 	return &Scheduler{
 		project:         project,
 		executorManager: executorManager,
-		sessionManager:  sessionManager,
 		executor:        gotaskflow.NewExecutor(concurrency),
 		tasks:           make(map[string]*gotaskflow.Task),
 		rootFlow:        gotaskflow.NewTaskFlow("bonk"),
@@ -116,19 +101,6 @@ func (s *Scheduler) AddTask(tsk task.Task, deps ...string) error {
 	return nil
 }
 
-func (s *Scheduler) Run(ctx context.Context) error {
-	s.sessionId = uuid.Must(uuid.NewV7())
-
-	if s.sessionManager != nil {
-		err := s.sessionManager.OpenSession(ctx, s.sessionId)
-		if err != nil {
-			return fmt.Errorf("failed to open task schedule: %w", err)
-		}
-
-		defer s.sessionManager.CloseSession(ctx, s.sessionId)
-	}
-
+func (s *Scheduler) Run() {
 	s.executor.Run(s.rootFlow).Wait()
-
-	return nil
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"cuelang.org/go/cue"
 
+	"github.com/google/uuid"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
@@ -30,11 +31,9 @@ func Test_SenderIsCalled(t *testing.T) {
 		Times(1).
 		Return(nil)
 
-	scheduler := NewScheduler(project, sender, nil, 1)
+	scheduler := NewScheduler(project, sender, 1)
 
-	err := scheduler.AddTask(task.New("test", "task1", cue.Value{}))
-	require.NoError(t, err)
+	require.NoError(t, scheduler.AddTask(task.New(uuid.Nil, "test", "task1", cue.Value{})))
 
-	err = scheduler.Run(t.Context())
-	require.NoError(t, err)
+	scheduler.Run()
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -30,9 +30,11 @@ func Test_SenderIsCalled(t *testing.T) {
 		Times(1).
 		Return(nil)
 
-	scheduler := NewScheduler(project, sender, 1)
+	scheduler := NewScheduler(project, sender, nil, 1)
 
-	require.NoError(t, scheduler.AddTask(task.New("test", "task1", cue.Value{})))
+	err := scheduler.AddTask(task.New("test", "task1", cue.Value{}))
+	require.NoError(t, err)
 
-	scheduler.Run()
+	err = scheduler.Run(t.Context())
+	require.NoError(t, err)
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -55,9 +55,10 @@ type Task struct {
 	OutputFs  afero.Fs `json:"-"`
 }
 
-func New(executor, name string, params cue.Value, inputs ...string) Task {
+func New(session uuid.UUID, executor, name string, params cue.Value, inputs ...string) Task {
 	return Task{
 		ID: TaskId{
+			Session:  session,
 			Executor: executor,
 			Name:     name,
 		},

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -25,6 +25,7 @@ func (id *TaskId) String() string {
 
 func (id *TaskId) GetChild(name, executor string) TaskId {
 	return TaskId{
+		Session:  id.Session,
 		Executor: executor,
 		Name:     fmt.Sprintf("%s.%s", id.Name, name),
 	}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -14,7 +14,7 @@ import (
 )
 
 type TaskId struct {
-	Session  uuid.UUID `json:"session"`
+	Session  uuid.UUID `json:"-"`
 	Name     string    `json:"name"`
 	Executor string    `json:"executor"`
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -9,12 +9,14 @@ import (
 
 	"cuelang.org/go/cue"
 
+	"github.com/google/uuid"
 	"github.com/spf13/afero"
 )
 
 type TaskId struct {
-	Name     string `json:"name"`
-	Executor string `json:"executor"`
+	Session  uuid.UUID `json:"session"`
+	Name     string    `json:"name"`
+	Executor string    `json:"executor"`
 }
 
 func (id *TaskId) String() string {

--- a/pkg/task/typed.go
+++ b/pkg/task/typed.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"cuelang.org/go/cue"
+
+	"github.com/google/uuid"
 )
 
 type TypedTask[Params any] struct {
@@ -16,6 +18,7 @@ type TypedTask[Params any] struct {
 }
 
 func NewTyped[Params any](
+	session uuid.UUID,
 	executor, name string,
 	cuectx *cue.Context,
 	params Params,
@@ -24,6 +27,7 @@ func NewTyped[Params any](
 	return TypedTask[Params]{
 		Task: Task{
 			ID: TaskId{
+				Session:  session,
 				Executor: executor,
 				Name:     name,
 			},

--- a/plugins/test/test_test.go
+++ b/plugins/test/test_test.go
@@ -8,6 +8,8 @@ import (
 
 	"cuelang.org/go/cue"
 
+	"github.com/google/uuid"
+
 	"go.bonk.build/pkg/task"
 	"go.bonk.build/test"
 )
@@ -20,7 +22,7 @@ func Test_Plugin(t *testing.T) {
 	var result task.Result
 	err := executors.Execute(
 		t.Context(),
-		task.New("Test", "testing", cue.Value{}),
+		task.New(uuid.Nil, "Test", "testing", cue.Value{}),
 		&result,
 	)
 	if err != nil {

--- a/test/testing.go
+++ b/test/testing.go
@@ -25,12 +25,6 @@ func ServeTest(t *testing.T, plugin *bonk.Plugin) executor.ExecutorManager {
 		},
 	})
 
-	t.Cleanup(func() {
-		// Close the GRPC infrastructure
-		require.NoError(t, client.Close())
-		server.Stop()
-	})
-
 	raw, err := client.Dispense("executor")
 	if err != nil {
 		t.Fatal("failed to dispense plugin:", err)
@@ -48,6 +42,12 @@ func ServeTest(t *testing.T, plugin *bonk.Plugin) executor.ExecutorManager {
 		if err != nil {
 			t.Fatal("failed to register executor:", name)
 		}
+	})
+
+	t.Cleanup(func() {
+		// Close the GRPC infrastructure
+		require.NoError(t, client.Close())
+		server.Stop()
 	})
 
 	return executorManager


### PR DESCRIPTION
This adds plumbing support for session management, which will be defined by an invocation of the build tool. This is primarily useful when considering long-running plugin processes.

Future work:
* pass workspace information about the session through to executors