### PR TITLE
ci: limit go test parallel workers to 8

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -54,7 +54,7 @@ jobs:
         run: go build ./...
 
       - name: go test
-        run: go tool gotestsum --packages="./..." --junitfile junit.xml --jsonfile gotest.json -- -coverprofile=coverage.txt -race -count 100
+        run: go tool gotestsum --packages="./..." --junitfile junit.xml --jsonfile gotest.json -- -coverprofile=coverage.txt -race -count 100 -parallel 8
 
       - name: process results for summary
         uses: robherley/go-test-action@b19f6aadabfb1ad85079065b21aa2af132466468 # v0.6.0


### PR DESCRIPTION
Hopefully this helps reduce spurious failures.